### PR TITLE
Trigger relayout for all nodes in response to pinch gestures

### DIFF
--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -108,7 +108,9 @@ class ViewController: ASViewController, UIGestureRecognizerDelegate {
             let progressHeight = ((transitionTargetSize.height - transitionPrevSize.height) * progress) + transitionPrevSize.height
             let progressiveSize = CGSize(width: progressWidth, height: progressHeight)
             
-            cellsToUpdateDuringTransition?.setNeedsLayout(progressiveSize)
+//            cellsToUpdateDuringTransition?.setNeedsLayout(progressiveSize)
+            viewModel.itemSize = progressiveSize
+            collectionNode.view.relayoutAllNodes()
             //Right now reloadData and layoutSubviews manually calls into the ASDataController to relayout the sizes of the collection view nodes. 🙈
             // https://github.com/facebook/AsyncDisplayKit/issues/691
             // https://github.com/facebook/AsyncDisplayKit/issues/866

--- a/Demo/ViewModel.swift
+++ b/Demo/ViewModel.swift
@@ -13,6 +13,7 @@ class ViewModel: NSObject, ASCollectionDelegate, ASCollectionDataSource {
     var loadedItemCount = 30
     let totalItemCount = 200
     let maxAdditionalToLoad = 30
+    var itemSize = CGSizeZero
     
     func numberOfSectionsInCollectionView(collectionView: UICollectionView) -> Int {
         return 1
@@ -35,7 +36,7 @@ class ViewModel: NSObject, ASCollectionDelegate, ASCollectionDataSource {
     
     func collectionView(collectionView: ASCollectionView, constrainedSizeForNodeAtIndexPath indexPath: NSIndexPath) -> ASSizeRange {
         guard let layout = collectionView.collectionViewLayout as? ASCollectionViewVerticalLayout else {
-            return ASSizeRange(min: CGSizeZero, max: CGSizeZero)
+            return ASSizeRange(min: itemSize, max: itemSize)
         }
         let size = layout.getItemSize(viewBounds: collectionView.bounds)
         return ASSizeRange(min: size, max: size)


### PR DESCRIPTION
It turns out we need to trigger relayout on all nodes and the best way to do it is to expose `relayoutAllNodes` of `ASDataController` at `ASCollectionView` level. Once `relayoutAllNodes` is called, `ViewModel` is asked to return new node sizes and the returned value needs to be correct.
